### PR TITLE
require endstamp on form

### DIFF
--- a/components/SceneForm.js
+++ b/components/SceneForm.js
@@ -168,6 +168,7 @@ const SceneForm = ({
                   fullWidth
                   type={'number'}
                   size="small"
+                  required
                   onWheel={event => event.target.blur ()}
                   InputProps={{
                     endAdornment: (


### PR DESCRIPTION
Issue: endstamp form field did not have a required prop set to true
-Can cause issues for looper in future if form field not set to required
Soln: set required to true